### PR TITLE
Backport changes made to bootstrap.css into scaleconf.less

### DIFF
--- a/less/scaleconf.less
+++ b/less/scaleconf.less
@@ -17,6 +17,12 @@ ul.scaleconf-heads li
     background-position: 0px;
     background-repeat: no-repeat;
 }
+div.sponsor-text p {
+  font-size:1.1em;
+}
+img.sponsor-logo {
+  margin: 0 auto;
+}
 ul.scaleconf-heads
 {
     margin-left: 13px;


### PR DESCRIPTION
Before:

```
adrian@toad:~/src/scaleconf.github.com$ diff -bu css/bootstrap.css css/bootstrap.css-new 
--- css/bootstrap.css   2014-10-15 13:46:31.580426191 +0200
+++ css/bootstrap.css-new   2014-10-22 15:51:43.488325289 +0200
@@ -5387,12 +5387,6 @@
   background-position: 0px;
   background-repeat: no-repeat;
 }
-div.sponsor-text p {
-  font-size:1.1em;
-}
-img.sponsor-logo {
-  margin: 0 auto;  
-}
 ul.scaleconf-heads {
   margin-left: 13px;
 }
```

After:

```
adrian@toad:~/src/scaleconf.github.com$ lessc less/bootstrap.less > css/bootstrap.css-new 
adrian@toad:~/src/scaleconf.github.com$ diff -bu css/bootstrap.css css/bootstrap.css-new 
--- css/bootstrap.css   2014-10-15 13:46:31.580426191 +0200
+++ css/bootstrap.css-new   2014-10-22 15:52:25.105185663 +0200
@@ -5388,7 +5388,7 @@
   background-repeat: no-repeat;
 }
 div.sponsor-text p {
-  font-size:1.1em;
+  font-size: 1.1em;
 }
 img.sponsor-logo {
   margin: 0 auto;  
```
