### PR TITLE
Update Tickets page before 9am 26 Jan

### DIFF
--- a/purchase/index.html
+++ b/purchase/index.html
@@ -13,9 +13,6 @@ title: Purchase Tickets
             <h2>Conference</h2>
             <p><strong>Dates:</strong> March 4-6, 2015 </p>
             <p><strong>Where:</strong> Kirstenbosch Botanical Gardens </p>
-            <p><strong>Day 1 (Business of Scale) Only: R700</strong> (Individual), <strong>R800</strong> (Corporate) </p>
-            <p><strong>Day 2 &amp; 3 (Technical Talks) Only: R1400</strong> (Individual), <strong>R1600</strong> (Corporate) </p>
-            <p><strong>All 3 Days: R2000</strong> (Individual), <strong>R2200</strong> (Corporate) </p>
             <p><strong>What's included in your ticket:</strong></p>
             <ul class="list-unstyled scaleconf-heads">
                 <li>International speakers sharing unique experiences.</li>
@@ -24,7 +21,8 @@ title: Purchase Tickets
                 <li>Evening events to network and meet like-minded people.</li>
                 <li>Free workshops, and time to build and hack with new technologies and people.</li>
             </ul>
-            <p><strong>Tickets are not yet open! Come back soon!</strong></p>
+            <p>To reduce complexity and ease your purchasing decisions this year we have just two simple options:</p>
+            <iframe src="https://www.quicket.co.za/embed.aspx?productid=7896&amp;productname=scaleconf&amp;embed=true" frameborder="0" scrolling="no" width="600" height="251"></iframe>
 
 
         </div>


### PR DESCRIPTION
http://scaleconf.org/purchase/

If we want widget code:

`<iframe src="https://www.quicket.co.za/embed.aspx?productid=7896&productname=scaleconf&embed=true" frameborder="0" scrolling="no" width="725" height="251"></iframe>`

URL: https://www.quicket.co.za/events/7896-scaleconf/

We should probably change the info on prices. Maybe explain why we no longer offer the early-bird pricing?