### PR TITLE
Update home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,16 +20,16 @@ title: Home
             <div class="col-xs-12 col-md-6">
                 <div class="paragraph-home">
                     <p>
-                        <em>{{ site.data.schedule[site.year].dates }} - Cape Town, South Africa</em>
+                        <em><!-- {{ site.data.schedule[site.year].dates }} - -->Located in Cape Town, South Africa</em>
                     </p>
                     <p>
                         Each year ScaleConf brings international and local experts together to talk about their experience building sites and services that can handle the rigours of today's internet.
                     </p>
                     <p>
-                        Back for the fourth time, the 2015 edition is going to be bigger and better than ever. We've got a third day with a focus on the scale of business, and a great lineup of speakers.
+                        We'll be back for the fifth time in March 2016 (exact dates to be confirmed).
                     </p>
                     <p>
-                        Unfortunately, tickets for ScaleConf 2015 are fully sold out.  Sign up to be notified about next year's conference in the form on the right.
+                        Sign up to be notified about next year's conference in the form on the right.
                     </p>
                 </div>
             </div>
@@ -87,8 +87,8 @@ title: Home
             </div>
             <div class="col-xs-12 col-md-8">
                 <div class="gray-background">
-                    <h2>HIGHLIGHTED SPEAKERS</h2>
-                    <p>With a mixture of African and international speakers, each year we bring a diversity of experience and perspective to the stage. Meet the engineers and business leaders who will share their war stories in 2015.</p>
+                    <h2>PREVIOUS SPEAKERS</h2>
+                    <p>With a mixture of African and international speakers, each year we bring a diversity of experience and perspective to the stage. Meet the engineers and business leaders who have shared their war stories at previous events.</p>
                     <div class="row padding-extra padding-extra-top">
                     {% for speaker in site.data.speakers.highlighted %}
                         <a href="/speakers/{{ speaker }}.html">
@@ -102,7 +102,7 @@ title: Home
                     </div>
                     <div class="row padding-extra">
                         <div class="col-xs-12 col-md-12">
-                            <h2 class="pull-right"><a href="/speakers/"> See the full list of 2015 speakers &gt;&gt;</a></h2>
+                            <h2 class="pull-right"><a href="/videos/"> Watch past talks &gt;&gt;</a></h2>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Consider commenting out rather than removing, so it makes for easier updating in the next few months.

***

> March 4-6 2015 - Cape Town, South Africa

> Each year ScaleConf brings international and local experts together to talk about their experience building sites and services that can handle the rigours of today's internet.

> Back for the fourth time, the 2015 edition is going to be bigger and better than ever. We've got a third day with a focus on the scale of business, and a great lineup of speakers.

> Unfortunately, tickets for ScaleConf 2015 are fully sold out. Sign up to be notified about next year's conference in the form on the right.

change to:

> Located in Cape Town, South Africa

> Each year ScaleConf brings international and local experts together to talk about their experience building sites and services that can handle the rigours of today's internet.

> We'll be back for the fifth time in 2016 (dates to be confirmed).

***

Keep the mailing list and quote.

***

> HIGHLIGHTED SPEAKERS

> With a mixture of African and international speakers, each year we bring a diversity of experience and perspective to the stage. Meet the engineers and business leaders who will share their war stories in 2015.

change to:

> PREVIOUS SPEAKERS

> With a mixture of African and international speakers, each year we bring a diversity of experience and perspective to the stage. Meet the engineers and business leaders who have shared their war stories at previous ScaleConf's (ScaleConfs?)