### PR TITLE
Update /speakers

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -1,5 +1,7 @@
 all_speakers_archive: [ beat_schwegler, dale_humby, daniel_fiske, daniel_schauenberg, david_tinker, mike_jones, miles_ward, neil_blakey_milner, patrick_turley, peter_lockhart, robert_stuttaford, simon_ratcliffe, niklas_gustavsson, aslam_khan, chris_bray, deon_moolman, clinton_gormley, beat_schwegler_2014, krzysztof_debski, shai_rosenfeld, dustin_whittle, zabil_cheriya_maliackal, simbarashe_nyatsa, simon_cross, wim_godden, ben_adlard, craig_robinson ]
-2015: [ franz_struwig, mark_forrester, robert_elliott, willem_van_biljon, charity_majors, matty_cohen, albert_dejongh, chris_oloff, donovan_graham, sam_laing, karen_greaves, jeanre_swanepoel, tim_park, shaun_norris, stephen_perelson, nick_pentreath, alex_koller, hiren_patel, maggie_zhou, paul_cartmel ]
+speakers_2015: [ franz_struwig, mark_forrester, robert_elliott, willem_van_biljon, charity_majors, matty_cohen, albert_dejongh, chris_oloff, donovan_graham, sam_laing, karen_greaves, jeanre_swanepoel, tim_park, shaun_norris, stephen_perelson, nick_pentreath, alex_koller, hiren_patel, maggie_zhou, paul_cartmel ]
+speakers_2014: [ niklas_gustavsson, clinton_gormley, deon_moolman, chris_bray, beat_schwegler_2014, krzysztof_debski, shai_rosenfeld, dustin_whittle, zabil_cheriya_maliackal, simbarashe_nyatsa, simon_cross, wim_godden, ben_adlard, craig_robinson, aslam_khan ]
+speakers_2013: [ beat_schwegler, dale_humby, daniel_fiske, daniel_schauenberg, david_tinker, mike_jones, miles_ward, neil_blakey_milner, patrick_turley, peter_lockhart, robert_stuttaford, simon_ratcliffe ]
 speakers_business: [ franz_struwig, mark_forrester, robert_elliott, willem_van_biljon, charity_majors_business, paul_cartmel ]
 speakers_technology: [ charity_majors, matty_cohen, albert_dejongh, chris_oloff, donovan_graham, sam_laing, karen_greaves, jeanre_swanepoel, tim_park, shaun_norris, stephen_perelson, nick_pentreath, alex_koller, hiren_patel, maggie_zhou ]
 highlighted: [ franz_struwig, willem_van_biljon, matty_cohen, stephen_perelson ]
@@ -9,31 +11,31 @@ bios:
 
     paul_cartmel:
         name: Paul Cartmel
-        company: New Media Labs 
+        company: New Media Labs
         role: Managing Director
         twitter: PaulCartmel
         country: SA
         bio: >
-            Paul is the Managing Director of New Media Labs. He has adopted the Jack Dorsey 
-            definition of CEO/MD – which makes him an editor. He edits their ideas, the 
-            story they tell the public, their strategy and make sure it is on course. 
-            Some would say a CEO controls the vision, but NML’s vision is a composite 
+            Paul is the Managing Director of New Media Labs. He has adopted the Jack Dorsey
+            definition of CEO/MD – which makes him an editor. He edits their ideas, the
+            story they tell the public, their strategy and make sure it is on course.
+            Some would say a CEO controls the vision, but NML’s vision is a composite
             of each individual that works there, so he just gets to edit it.
-            Keeping an incredibly talented team close is his real goal – a talented team 
-            sells itself. To achieve this he strives to make New Media Labs a place the team 
+            Keeping an incredibly talented team close is his real goal – a talented team
+            sells itself. To achieve this he strives to make New Media Labs a place the team
             want to spend their working life at. He sees employing people as an honour.
         title: >
             Business Day Interview: New Media Labs
         abstract: >
             While leading NML Paul has led his team through many twists and turns. We'll talk
             to him about growing a successful, independent consulting business with one eye (and
-            sometimes two) on productising the work they engage in. We'll touch on how he believes 
+            sometimes two) on productising the work they engage in. We'll touch on how he believes
             you could structure a business to increase the probability of success and discuss the real
             world impact internal decisions and external forces have shaped the road they've walked.
 
     stephen_perelson:
         name: Stephen Perelson
-        company: Mxit 
+        company: Mxit
         role: Senior Web Engineer
         twitter: perelson
         country: SA
@@ -63,22 +65,22 @@ bios:
         twitter: timpark
         country: USA
         bio: >
-            Tim is a principal software engineer at Microsoft, working with customers and 
-            product teams to prove out scenarios on the Microsoft cloud that have never 
-            been done elsewhere and use that experience to drive improvements in our 
-            products. Before Microsoft, Tim worked on a number of the key pieces of 
-            infrastructure and applications at Nest Labs, an internet of things startup 
+            Tim is a principal software engineer at Microsoft, working with customers and
+            product teams to prove out scenarios on the Microsoft cloud that have never
+            been done elsewhere and use that experience to drive improvements in our
+            products. Before Microsoft, Tim worked on a number of the key pieces of
+            infrastructure and applications at Nest Labs, an internet of things startup
             that re-envisioned the thermostat for the digital era.
         title: From Screens to Context
         abstract: >
-            For the past four decades computing has been driven by the spiral of faster, 
-            cheaper, and smaller but has stayed within the lines of a "screen and an input 
-            device". Tim will talk about how computing is increasingly being infused into 
-            everything and that increasingly the user interface for this style of computing 
-            will be our use of our everyday things. He will talk about the impact of this 
-            on how we build and scale systems and draw on his experience of working at 
-            Nest Labs (an early Internet of Things startup) and in cloud services at 
-            Microsoft to describe how to ingest and process extremely high scale telemetry 
+            For the past four decades computing has been driven by the spiral of faster,
+            cheaper, and smaller but has stayed within the lines of a "screen and an input
+            device". Tim will talk about how computing is increasingly being infused into
+            everything and that increasingly the user interface for this style of computing
+            will be our use of our everyday things. He will talk about the impact of this
+            on how we build and scale systems and draw on his experience of working at
+            Nest Labs (an early Internet of Things startup) and in cloud services at
+            Microsoft to describe how to ingest and process extremely high scale telemetry
             data and ground the discussion by walking through a real world customer scenario.
 
     franz_struwig:
@@ -88,16 +90,16 @@ bios:
         twitter: fstruwig
         country: SA
         bio: >
-            Franz is passionate about people, technology and business. As an Engineer and an MBA, 
-            he was privileged to be a part of establishing iKubu – a radar and computer vision 
-            company with a heart. After crowdfunding the world’s first bicycle radar called 
+            Franz is passionate about people, technology and business. As an Engineer and an MBA,
+            he was privileged to be a part of establishing iKubu – a radar and computer vision
+            company with a heart. After crowdfunding the world’s first bicycle radar called
             Backtracker in 2014, iKubu was acquired by Garmin. He's still learning and growing!
         title: >
             Business Day Interview: Garmin
-        abstract: > 
-            At iKubu they help people see what they can't, using computer vision and 
-            radar systems. We'll be talking Franz about the journey iKubu has been on over the 
-            last seven years from inception, growth to sale and what it took to realise the 
+        abstract: >
+            At iKubu they help people see what they can't, using computer vision and
+            radar systems. We'll be talking Franz about the journey iKubu has been on over the
+            last seven years from inception, growth to sale and what it took to realise the
             potential of a group of highly skilled engineers.
 
     mark_forrester:
@@ -106,17 +108,17 @@ bios:
         role: Co-Founder
         country: SA
         twitter: mark_forrester
-        bio: > 
-            Mark is a web designer turned online entrepreneur, now managing an international 
-            team spanning 16 countries, dedicated to helping businesses succeed through innovative 
-            WordPress themes and plugins. Proudly a Capetonian, husband, and dad. Avid sports 
+        bio: >
+            Mark is a web designer turned online entrepreneur, now managing an international
+            team spanning 16 countries, dedicated to helping businesses succeed through innovative
+            WordPress themes and plugins. Proudly a Capetonian, husband, and dad. Avid sports
             fan and wannabe surfer.
         title: >
             Business Day Interview: WooThemes
-        abstract: > 
+        abstract: >
             WooThemes is not just any old WordPress theme maker. They are responsible for
              WooCommerce - the fastest growing ecommerce platform online. We'll be talking to Mark
-             about where his creative inspiration comes from, how he has applied that to helping 
+             about where his creative inspiration comes from, how he has applied that to helping
              shape and manage the organisation and navigating the twists and turns of a maturing platform.
 
     robert_elliott:
@@ -125,16 +127,16 @@ bios:
         role: Co-Founder
         country: SA
         twitter: greenafrican
-        bio: > 
-            Robert is passionate about user experiences at the confluence of ecommerce, design and data science. 
-            He obsesses over flow, usability and simplicity. Pirate of Good Hope. 
+        bio: >
+            Robert is passionate about user experiences at the confluence of ecommerce, design and data science.
+            He obsesses over flow, usability and simplicity. Pirate of Good Hope.
         title: >
             Business Day Interview: Graphflow
-        abstract: > 
-            Graphflow are passionate about small business and believe that even the smallest store 
-            should have access to the same technology the big guys are using. They created a tool that allows 
-            them to get the edge over the competition by plugging into the power of Machine Learning and 
-            Big Data technologies. We'll be talking to Rob about product ideation and realisation in the context 
+        abstract: >
+            Graphflow are passionate about small business and believe that even the smallest store
+            should have access to the same technology the big guys are using. They created a tool that allows
+            them to get the edge over the competition by plugging into the power of Machine Learning and
+            Big Data technologies. We'll be talking to Rob about product ideation and realisation in the context
             of a small but expert team and the experience of being part of a local incubator.
 
     willem_van_biljon:
@@ -142,17 +144,17 @@ bios:
         company: Takealot
         role: Co-CEO and Chief Technology Officer
         country: SA
-        bio: > 
-            Willem is a seasoned technology entrepreneur, having co-founded Mosaic Software, the creators of the 
+        bio: >
+            Willem is a seasoned technology entrepreneur, having co-founded Mosaic Software, the creators of the
             Postilion payment system, and was one of the leaders that built Amazon’s EC2 cloud service and Nimbula.
-            In June 2014 he joined South Africa’s fastest growing online retailer takealot.com as 
+            In June 2014 he joined South Africa’s fastest growing online retailer takealot.com as
             Co-CEO and Chief Technology Officer.
         title: >
             Business Day Interview: Takealot
-        abstract: > 
-            Willem brings a unique perspective to ScaleConf given his vast experience in companies small 
+        abstract: >
+            Willem brings a unique perspective to ScaleConf given his vast experience in companies small
             and large. We'll be talking to him about his multi-decade journey in the industry and getting his
-            thoughts on the challenges and joys of growing of technology business both in South Africa 
+            thoughts on the challenges and joys of growing of technology business both in South Africa
             and internationally.
 
     charity_majors:
@@ -161,18 +163,18 @@ bios:
         role: Production Engineering Manager
         country: USA
         twitter: mipsytipsy
-        bio: > 
+        bio: >
             Charity is happily building out the next generation of mobile backends as a service at Parse.
             She enjoys free software, free speech and single malt scotch.
         title: >
             Upgrade your database: without losing your data, your perf or your mind
-        abstract: > 
-            Upgrading databases can be terrifying and perilous, and for good reason: you can totally 
-            screw yourself! Every workload is unique and standardized test suites will never give you 
-            enough information to evaluate how an upgrade will perform for your query set. We will talk 
-            about how paranoid you should be about various types of workloads and upgrades, how to balance 
-            risk vs engineering effort, and how to safely execute the most challenging upgrades by capturing 
-            and replaying real production workloads. The principles apply to any db, but we’ll go 
+        abstract: >
+            Upgrading databases can be terrifying and perilous, and for good reason: you can totally
+            screw yourself! Every workload is unique and standardized test suites will never give you
+            enough information to evaluate how an upgrade will perform for your query set. We will talk
+            about how paranoid you should be about various types of workloads and upgrades, how to balance
+            risk vs engineering effort, and how to safely execute the most challenging upgrades by capturing
+            and replaying real production workloads. The principles apply to any db, but we’ll go
             particularly deep into war stories and tooling options for MongoDB and MySQL.
 
     charity_majors_business:
@@ -181,15 +183,15 @@ bios:
         role: Production Engineering Manager
         country: USA
         twitter: mipsytipsy
-        bio: > 
+        bio: >
             Charity is happily building out the next generation of mobile backends as a service at Parse.
             She enjoys free software, free speech and single malt scotch.
         title: >
             Business Day Interview: Parse
-        abstract: > 
-            As a Production Engineering Manager at Parse, a mobile app platform for developers which is now a part 
+        abstract: >
+            As a Production Engineering Manager at Parse, a mobile app platform for developers which is now a part
             of Facebook, Charity has lived through the reality of the tiny-to-25-to-8000 person transition.
-            We'll be dicussing her experience of being acquired, deploying large systems at scale and advice for 
+            We'll be dicussing her experience of being acquired, deploying large systems at scale and advice for
             how to stay productive and work better with your team through those transitions.
 
     matty_cohen:
@@ -220,32 +222,32 @@ bios:
             humble technology enthusiast.  He is an agile and UX practitioner,
             who has been a scrum master and product owner in previous lives.
         title: Scaling your Front-end
-        abstract: 
+        abstract:
 
     albert_dejongh:
         name: Albert De Jongh
         company: Visa
         role: Software Architect
         country: SA
-        twitter: 
-        bio: > 
-            Albert is a software architect at Visa, and has often found himself in war rooms 
-            about performance problems.  He has stared at way too many thread dumps, trying to make 
+        twitter:
+        bio: >
+            Albert is a software architect at Visa, and has often found himself in war rooms
+            about performance problems.  He has stared at way too many thread dumps, trying to make
             sense of things that just could not have happened.
         title: Banana for Scale
-        abstract: > 
-            Heavily loaded transaction processing systems, struggling clients...  Albert and 
-            Chris have been faced with scaling challenges like these, and would like to share their 
-            experience. They will present some lessons learnt and they’ll explain why bananas were 
+        abstract: >
+            Heavily loaded transaction processing systems, struggling clients...  Albert and
+            Chris have been faced with scaling challenges like these, and would like to share their
+            experience. They will present some lessons learnt and they’ll explain why bananas were
             not suitable for scale.
 
     albert_and_chris:
         name: Albert De Jongh and Chris Oloff
         title: Banana for Scale
-        abstract: > 
-            Heavily loaded transaction processing systems, struggling clients...  Albert and 
-            Chris have been faced with scaling challenges like these, and would like to share their 
-            experience. They will present some lessons learnt and they’ll explain why bananas were 
+        abstract: >
+            Heavily loaded transaction processing systems, struggling clients...  Albert and
+            Chris have been faced with scaling challenges like these, and would like to share their
+            experience. They will present some lessons learnt and they’ll explain why bananas were
             not suitable for scale.
 
     chris_oloff:
@@ -255,17 +257,17 @@ bios:
         country: SA
         twitter: chrisoloff
         bio: >
-            Chris' goal is to write efficient and well-performing code for small and not-so-small-any-more 
-            challenges, since 1994, with existing or news teams. He gained experience in diverse industries 
-            like metals, money and energy, and is still learning daily. Chris holds an Honours Degree in 
+            Chris' goal is to write efficient and well-performing code for small and not-so-small-any-more
+            challenges, since 1994, with existing or news teams. He gained experience in diverse industries
+            like metals, money and energy, and is still learning daily. Chris holds an Honours Degree in
             Computer Science and Economics from the University of Mannheim, Germany.
         title: Banana for Scale
-        abstract: > 
-            Heavily loaded transaction processing systems, struggling clients...  Albert and 
-            Chris have been faced with scaling challenges like these, and would like to share their 
-            experience. They will present some lessons learnt and they’ll explain why bananas were 
+        abstract: >
+            Heavily loaded transaction processing systems, struggling clients...  Albert and
+            Chris have been faced with scaling challenges like these, and would like to share their
+            experience. They will present some lessons learnt and they’ll explain why bananas were
             not suitable for scale.
-    
+
     alex_and_hiren:
         name: Alex Koller and Hiren Patel
         title: An AppDev approach to scale
@@ -343,29 +345,29 @@ bios:
         role: Co-founder
         country: SA
         twitter: samlaing
-        bio: > 
-            Sam works as a coach and trainer helping teams and individuals adopt agile and work more effectively. 
-            Although her background is as a software developer, she uses agile techniques with many different 
-            industries and teams. Her goal is to make the process from idea to execution more rewarding for 
+        bio: >
+            Sam works as a coach and trainer helping teams and individuals adopt agile and work more effectively.
+            Although her background is as a software developer, she uses agile techniques with many different
+            industries and teams. Her goal is to make the process from idea to execution more rewarding for
             everyone involved.
         title: Scaling Learning
-        abstract: > 
-            To succeed in todays world you need to be continuously learning. Along with that comes 
-            the time pressure of todays world - so when and how are you learning? Sam and Karen have been 
-            doing in person training for many years and recently stepped into the world on online training. 
-            Training at scale. How do you make online training as valuable as in person training - is it 
-            possible? This talk is about their adventure into the online education world, what they 
+        abstract: >
+            To succeed in todays world you need to be continuously learning. Along with that comes
+            the time pressure of todays world - so when and how are you learning? Sam and Karen have been
+            doing in person training for many years and recently stepped into the world on online training.
+            Training at scale. How do you make online training as valuable as in person training - is it
+            possible? This talk is about their adventure into the online education world, what they
             learned, what surprised them and how it has affected their company.
 
     sam_and_karen:
         name: Sam Laing and Karen Greaves
         title: Scaling Learning
-        abstract: > 
-            To succeed in todays world you need to be continuously learning. Along with that comes 
-            the time pressure of todays world - so when and how are you learning? Sam and Karen have been 
-            doing in person training for many years and recently stepped into the world on online training. 
-            Training at scale. How do you make online training as valuable as in person training - is it 
-            possible? This talk is about their adventure into the online education world, what they 
+        abstract: >
+            To succeed in todays world you need to be continuously learning. Along with that comes
+            the time pressure of todays world - so when and how are you learning? Sam and Karen have been
+            doing in person training for many years and recently stepped into the world on online training.
+            Training at scale. How do you make online training as valuable as in person training - is it
+            possible? This talk is about their adventure into the online education world, what they
             learned, what surprised them and how it has affected their company.
 
     karen_greaves:
@@ -374,17 +376,17 @@ bios:
         role: Co-founder
         country: SA
         twitter: karen_greaves
-        bio: > 
-            Karen believes the best way to engage people at work is to make sure they are having fun, making 
-            a difference, and getting better at the things they do. She helps people build great teams and 
+        bio: >
+            Karen believes the best way to engage people at work is to make sure they are having fun, making
+            a difference, and getting better at the things they do. She helps people build great teams and
             deliver great software.
         title: Scaling Learning
-        abstract: >  
-            To succeed in todays world you need to be continuously learning. Along with that comes 
-            the time pressure of todays world - so when and how are you learning? Sam and Karen have been 
-            doing in person training for many years and recently stepped into the world on online training. 
-            Training at scale. How do you make online training as valuable as in person training - is it 
-            possible? This talk is about their adventure into the online education world, what they 
+        abstract: >
+            To succeed in todays world you need to be continuously learning. Along with that comes
+            the time pressure of todays world - so when and how are you learning? Sam and Karen have been
+            doing in person training for many years and recently stepped into the world on online training.
+            Training at scale. How do you make online training as valuable as in person training - is it
+            possible? This talk is about their adventure into the online education world, what they
             learned, what surprised them and how it has affected their company.
 
     jeanre_swanepoel:
@@ -393,17 +395,17 @@ bios:
         role: Software Architect and Founder
         country: SA
         twitter: jeanres
-        bio: > 
-            Jeanre is a software architect and the founder of Ikhasi Digital, a small software 
-            company based in Cape Town and Johannesburg, South Africa. He has over 10 years experience in 
-            software development and infrastructure management, with proficiency in Node.JS, Java, .NET, 
-            Ruby on Rails and Python. He brings experience in building large scale video streaming 
+        bio: >
+            Jeanre is a software architect and the founder of Ikhasi Digital, a small software
+            company based in Cape Town and Johannesburg, South Africa. He has over 10 years experience in
+            software development and infrastructure management, with proficiency in Node.JS, Java, .NET,
+            Ruby on Rails and Python. He brings experience in building large scale video streaming
             applications, high volume realtime communication platforms and large e-commerce solutions.
         title: Scaling Product Development with Open Source Technologies
-        abstract: > 
-            Jeanre will be talking and demonstrating how they work as a development team on a daily 
-            basis with developers across the globe and no central offices. All the software that they use 
-            is free and open source. The talk will touch on: continuous integration and deployment, 
+        abstract: >
+            Jeanre will be talking and demonstrating how they work as a development team on a daily
+            basis with developers across the globe and no central offices. All the software that they use
+            is free and open source. The talk will touch on: continuous integration and deployment,
             infrastructure provisioning, auto scaling and finally team communication and collaboration.
 
     shaun_norris:
@@ -411,15 +413,15 @@ bios:
         company: Amazon Web Services
         role: Head of Solutions Architecture - ASEAN
         country: Singapore
-        bio: > 
-            Shaunn is Head of Solutions Architecture - ASEAN at Amazon Web Services and works with AWS 
+        bio: >
+            Shaunn is Head of Solutions Architecture - ASEAN at Amazon Web Services and works with AWS
             customers in the ASEAN region. He has been in the IT industry for 16 years in technical and
-            management roles for a variety of e-commerce and IT security companies in Canada, UK, 
-            Switzerland and South Africa. More recently, Shaun led the AWS Premium Support team in 
-            Cape Town, South Africa prior to joining the AWS team in Singapore. Shaun is also a 
+            management roles for a variety of e-commerce and IT security companies in Canada, UK,
+            Switzerland and South Africa. More recently, Shaun led the AWS Premium Support team in
+            Cape Town, South Africa prior to joining the AWS team in Singapore. Shaun is also a
             certified Scrum Master and Project Management Professional.
         title: From Horses to Unicorns - Practical DevOps tools and tips on AWS
-        abstract: > 
+        abstract: >
 
     nick_pentreath:
         name: Nick Pentreath
@@ -427,22 +429,22 @@ bios:
         role: Co-Founder
         country: SA
         twitter: MLnick
-        bio: > 
-            Nick is a cofounder of Graphflow, a big data and machine learning company focused on 
-            recommendations and customer intelligence. Nick has a background in financial markets, 
-            machine learning and software development. He has worked at Goldman Sachs and as a 
-            research scientist at online ad targeting startup Cognitive Match in London, and led 
-            the Data Science and Analytics team at Mxit, Africa’s largest social network. He is 
-            passionate about combining commercial focus with machine learning and cutting-edge 
+        bio: >
+            Nick is a cofounder of Graphflow, a big data and machine learning company focused on
+            recommendations and customer intelligence. Nick has a background in financial markets,
+            machine learning and software development. He has worked at Goldman Sachs and as a
+            research scientist at online ad targeting startup Cognitive Match in London, and led
+            the Data Science and Analytics team at Mxit, Africa’s largest social network. He is
+            passionate about combining commercial focus with machine learning and cutting-edge
             technology to build intelligent systems that learn from data to add value to the bottom line.
         title: Large Scale Data Processing
-        abstract: > 
-            This talk will give an overview of the MapReduce approach to large-scale data 
-            processing popularised by Apache Hadoop, and then move on to introduce the Apache 
+        abstract: >
+            This talk will give an overview of the MapReduce approach to large-scale data
+            processing popularised by Apache Hadoop, and then move on to introduce the Apache
             Spark project and the basics of working with Spark.
-            Apache Spark is a fast and general engine for large-scale, distributed data processing. 
-            It offers high-level APIs in Java, Scala and Python as well as a rich set of libraries 
-            including a SQL engine, stream processing, machine learning, and graph analytics. Spark 
+            Apache Spark is a fast and general engine for large-scale, distributed data processing.
+            It offers high-level APIs in Java, Scala and Python as well as a rich set of libraries
+            including a SQL engine, stream processing, machine learning, and graph analytics. Spark
             is currently one of the most exciting and fastest-growing Apache open source projects.
 
     jeff_ferland:
@@ -452,17 +454,17 @@ bios:
         country: USA
         twitter: jbferland
         bio: >
-            Jeff is a Production Engineer working on the messaging backend stack at Facebook 
+            Jeff is a Production Engineer working on the messaging backend stack at Facebook
             and a moderator for the Security StackExchange website.
         title: >
             Stalling Out: When Services Magically Stop Servicing Requests
         abstract: >
-            Diagnosing and preventing service failure caused by internal resource starvation: something 
-            that usually presents itself as “My service stopped working and I don’t know why, then 
-            started working and I don’t know why.” With an emphasis on failure-mode behavior, this talk 
-            will cover interactions between threading, multiple shards hosted by a single instance, 
-            kernel memory allocation behaviors, and NUMA-related problems. The talk will include 
-            information to collect on a regular basis for post-mortem analysis and sharing production 
+            Diagnosing and preventing service failure caused by internal resource starvation: something
+            that usually presents itself as “My service stopped working and I don’t know why, then
+            started working and I don’t know why.” With an emphasis on failure-mode behavior, this talk
+            will cover interactions between threading, multiple shards hosted by a single instance,
+            kernel memory allocation behaviors, and NUMA-related problems. The talk will include
+            information to collect on a regular basis for post-mortem analysis and sharing production
             lessons with software engineering teams.
 
     maggie_zhou:
@@ -472,13 +474,13 @@ bios:
         country: USA
         twitter: zmagg
         bio: >
-            Maggie works on the Core Platform team at Etsy where she builds infrastructure to manage scaling 
-            challenges in data storage and the web stack. She reads books, rides bicycles, and drinks 
+            Maggie works on the Core Platform team at Etsy where she builds infrastructure to manage scaling
+            challenges in data storage and the web stack. She reads books, rides bicycles, and drinks
             too much coffee in Brooklyn NY.
         title: >
             Sharding Take Two, the Logical Edition
         abstract: >
-            In this talk, we'll go over the pains and perils of sharding databases and how we solved 
+            In this talk, we'll go over the pains and perils of sharding databases and how we solved
             some of the problems in Etsy's second take on sharding, what we call logical sharding.
 
     craig_robinson:

--- a/speakers/index.html
+++ b/speakers/index.html
@@ -11,7 +11,9 @@ title: Speakers
 <div class="row white-background">
     <div class="col-md-12">
         <p>
-           With a mixture of African and international speakers, we're bringing a diversity of experience and perspective to the stage. Meet the engineers who will share their war stories.
+           With a mixture of African and international speakers, ScaleConf brings a
+           diversity of experience and perspective to the stage. Meet the speakers
+           who have shared their war stories.
         </p>
 
         <p>

--- a/speakers/index.html
+++ b/speakers/index.html
@@ -21,9 +21,10 @@ title: Speakers
         </p>
     </div>
 </div>
+
 <div class="row white-background">
     <div class="col-md-12">
-        <h2>Business of Scale</h2>
+        <h2>2015 - Business of Scale</h2>
     </div>
 </div>
 {% for speaker in site.data.speakers.speakers_business %}
@@ -58,10 +59,80 @@ title: Speakers
 <div class="row white-background">
     <div class="col-md-12">
         <hr>
-        <h2>Technology of Scale</h2>
+        <h2>2015 - Technology of Scale</h2>
     </div>
 </div>
 {% for speaker in site.data.speakers.speakers_technology %}
+    {% assign bio = site.data.speakers.bios.[speaker] %}
+    {% assign newrow = forloop.index0 | modulo: 3 %}
+
+{% if newrow == 0 %}
+<div class="row white-background">
+{% endif %}
+    <div class="col-xs-12 col-md-3">
+
+            <div class="box">
+                <a href="/speakers/{{ speaker }}.html">
+                <div class="row">
+                    <div class="col-xs-5 col-md-5 gutter-padding-right">
+                        <img src="/img/speakers/{{ speaker }}.large.jpg" class="img-responsive profile">
+                    </div>
+                    <div class="col-xs-7 col-md-7 gutter-padding-left">
+                        <h3 class="speaker">{{ bio.name }}</h3>
+                        {{ bio.company }}<br />
+                        {{ bio.role }}
+                    </div>
+                </div>
+                </a>
+            </div>
+    </div>
+{% if newrow == 2 or forloop.last %}
+</div>
+{% endif %}
+{% endfor %}
+
+<div class="row white-background">
+    <div class="col-md-12">
+        <hr>
+        <h2>2014 - Technology of Scale</h2>
+    </div>
+</div>
+{% for speaker in site.data.speakers.speakers_2014 %}
+    {% assign bio = site.data.speakers.bios.[speaker] %}
+    {% assign newrow = forloop.index0 | modulo: 3 %}
+
+{% if newrow == 0 %}
+<div class="row white-background">
+{% endif %}
+    <div class="col-xs-12 col-md-3">
+
+            <div class="box">
+                <a href="/speakers/{{ speaker }}.html">
+                <div class="row">
+                    <div class="col-xs-5 col-md-5 gutter-padding-right">
+                        <img src="/img/speakers/{{ speaker }}.large.jpg" class="img-responsive profile">
+                    </div>
+                    <div class="col-xs-7 col-md-7 gutter-padding-left">
+                        <h3 class="speaker">{{ bio.name }}</h3>
+                        {{ bio.company }}<br />
+                        {{ bio.role }}
+                    </div>
+                </div>
+                </a>
+            </div>
+    </div>
+{% if newrow == 2 or forloop.last %}
+</div>
+{% endif %}
+{% endfor %}
+
+<div class="row white-background">
+    <div class="col-md-12">
+        <hr>
+        <h2>2013 - Technology of Scale</h2>
+    </div>
+</div>
+{% for speaker in site.data.speakers.speakers_2013 %}
     {% assign bio = site.data.speakers.bios.[speaker] %}
     {% assign newrow = forloop.index0 | modulo: 3 %}
 


### PR DESCRIPTION
Update the page to include all previous speakers. We'll need to organise it - by conference date?

***

> With a mixture of African and international speakers, we're bringing a diversity of experience and perspective to the stage. Meet the engineers who will share their war stories.

Change to:

> With a mixture of African and international speakers, ScaleConf brings a diversity of experience and perspective to the stage. Meet the speakers who have shared their war stories.

***

> Previous speakers with videos and slides can be found here (http://scaleconf.org/videos).

***

*List the past speakers*

## 2015

### Business of Scale

Franz Struwig
Mark Forrester
...etc

### Technology of Scale

Charity Majors
Matty Cohen
...etc

## 2014
## 2013
## 2012