### PR TITLE
Fixing typo in Community block on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@ title: Home
 
       <div class="col-md-4">
         <h3>Community</h2>
-        <p>This site is hosted on <a href='https://github.com/scaleconf/scaleconf.github.com'>Github</a>, please feel free tolook around and contribute.</p>
+        <p>This site is hosted on <a href='https://github.com/scaleconf/scaleconf.github.com'>Github</a>, please feel free to look around and contribute.</p>
         <p>We are also on <a href='http://lanyrd.com/series/scaleconf/'>Lanyrd</a> if you want to follow us there.</p>
         <p><a href="/codeofconduct">code of conduct</a></p>
       </div>


### PR DESCRIPTION
Add missing space between the words _to_ and _look_

Original text: _please feel free tolook around and contribute_

New text: _please feel free to look around and contribute_