### PR TITLE
Add venue/date to /submit

### DIFF
--- a/submit-talk/index.html
+++ b/submit-talk/index.html
@@ -13,7 +13,7 @@ title: Submit a talk
       stories - and we would love you to step up.
     </p>
     <p>
-      ScaleConf will be held on 10-11 March 2017 in the Old Mutual Conference 
+      ScaleConf will be held on 9-10 March 2017 in the Old Mutual Conference 
       Centre at the Kirstenbosch Botanical Gardens.
     </p>
     <p>

--- a/submit-talk/index.html
+++ b/submit-talk/index.html
@@ -13,6 +13,10 @@ title: Submit a talk
       stories - and we would love you to step up.
     </p>
     <p>
+      ScaleConf will be held on 10-11 March 2017 in the Old Mutual Conference 
+      Centre at the Kirstenbosch Botanical Gardens.
+    </p>
+    <p>
       <a href="https://docs.google.com/forms/d/e/1FAIpQLSd7Lhg58L9TetXOn20dB_lBInnY4Frnki7vcBUk4zFFfx137A/viewform#response=ACYDBNiG3tNSRg06F0B-CQhpCP19ooIkugbCOQQDBjY6yLZDoowUwncH3MWD9w" target="_blank" class="btn btn-primary">
          Submit a talk
       </a>


### PR DESCRIPTION
I was going to link it to the venue page but we don’t seem to have one - didn’t we used to? Am I blind?