### PR TITLE
Update reference to Praekelt.org

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -15,7 +15,7 @@
 
 mary_racter:
     name: Mary Racter
-    company: Praekelt
+    company: Praekelt.org
     role: Security Engineer
     twitter: mracter
     github:


### PR DESCRIPTION
Praekelt.org is the organisation's full name.