### PR TITLE
Fetch fonts over https

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,7 +9,7 @@
     <link href="/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css" />
     <link href="/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
     <link href="/css/scaleconf.css" rel="stylesheet" type="text/css" />
-    <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700|Quicksand:300,400,700' rel='stylesheet' type='text/css' />
+    <link href='https://fonts.googleapis.com/css?family=Droid+Sans:400,700|Quicksand:300,400,700' rel='stylesheet' type='text/css' />
 
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>


### PR DESCRIPTION
Now that GitHub Pages allows https, https://scaleconf.org/ works. When
visiting this version of the site, the fonts don't load. I assume it's
the browser not fetching non-https content. This fixes that.