### PR TITLE
Update aruba

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -81,8 +81,9 @@ sponsors:
       <p>
       Today, our product is the fastest growing in the Aruba portfolio and our Cape
       Town-based team is recognised as being at the leading edge of design thinking
-      and execution. We are growing our team, building new products, and scaling
-      our systems to meet a >20x surge in demand during the next 12-18 months.
+      and execution. We are <a href='https://capenetworks.com/careers'>growing our
+      team</a>, building new products, and scaling our systems to meet a >20x surge
+      in demand during the next 12-18 months.
        </p>
   - name: dimensiondata
     active: false

--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@ title: Home
     </div>
     <div class="row">
       {% for sponsor in landing_page_sponsors %}
-      <div class="col-md-6" style="height:150px; overflow-y:hidden">
+      <div class="col-md-6" style="height:200px; overflow-y:hidden">
         <img src='/img/sponsors/{{ sponsor.name | slugify | replace: '-', '_' }}.large.png' style='display:inline-block; vertical-align:top; width:90%;'/>
       </div>
       {% endfor %}


### PR DESCRIPTION
* Add a link to their recruiting page
* Fix the chopped off logo

I wanted to align the sponsor images on the homepage so that they were vertically middle aligned but changing 
`        <img src='/img/sponsors/{{ sponsor.name | slugify | replace: '-', '_' }}.large.png' style='display:inline-block; vertical-align:top; width:90%;'/>
`
to
`        <img src='/img/sponsors/{{ sponsor.name | slugify | replace: '-', '_' }}.large.png' style='display:inline-block; vertical-align:middle; width:90%;'/>
`
didn't make a difference. If someone could let me know what it should be, then I can make the change in the next round :)