### PR TITLE
Use object-fit so sponsor logos don't crop in full screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@ title: Home
     <div class="row">
       {% for sponsor in landing_page_sponsors %}
       <div class="col-md-6" style="height:200px; overflow-y:hidden">
-        <img src='/img/sponsors/{{ sponsor.name | slugify | replace: '-', '_' }}.large.png' style='display:inline-block; vertical-align:top; width:90%;'/>
+        <img src='/img/sponsors/{{ sponsor.name | slugify | replace: '-', '_' }}.large.png' style='display:inline-block; vertical-align:top; width:90%; height:100%; object-fit:scale-down;'/>
       </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
Need to set height explicitly too, based on answer in https://stackoverflow.com/a/52682038

Old:
![Screenshot 2019-12-19 at 11 10 55](https://user-images.githubusercontent.com/5757543/71169181-40510100-2250-11ea-87c5-da8d8c7ef540.png)

New:
![Screenshot 2019-12-19 at 11 10 47](https://user-images.githubusercontent.com/5757543/71169189-45ae4b80-2250-11ea-8a17-c76bea187e4c.png)

